### PR TITLE
Add skip-version-footer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ jobs:
 | `values-file` | Path to values file | `values.yaml` | false |
 | `output-file` | Markdown file path relative to each chart directory to which rendered documentation will be written | `README.md` | false |
 | `template-files` | Comma separated list of template files to render | `README.md.gotmpl` | false |
-| `sort-order` | Order in which to sort the values table | unset | false |
+| `sort-values-order` | Order in which to sort the values table | unset | false |
 | `skip-version-footer` | If true the helm-docs version footer will not be shown in the default README template | false | false |
 | `git-push` | If true it will commit and push the changes (ignored if `fail-on-diff` is set) | `false` | false |
 | `git-push-user-name` | If empty the name of the GitHub Actions bot will be used | `github-actions[bot]` | false |

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ jobs:
 | `output-file` | Markdown file path relative to each chart directory to which rendered documentation will be written | `README.md` | false |
 | `template-files` | Comma separated list of template files to render | `README.md.gotmpl` | false |
 | `sort-order` | Order in which to sort the values table | unset | false |
+| `skip-version-footer` | If true the helm-docs version footer will not be shown in the default README template | false | false |
 | `git-push` | If true it will commit and push the changes (ignored if `fail-on-diff` is set) | `false` | false |
 | `git-push-user-name` | If empty the name of the GitHub Actions bot will be used | `github-actions[bot]` | false |
 | `git-push-user-email` | If empty the no-reply email of the GitHub Actions bot will be used | `github-actions[bot]@users.noreply.github.com` | false |

--- a/dist/index.js
+++ b/dist/index.js
@@ -34616,6 +34616,7 @@ async function run() {
         const outputFile = core.getInput('output-file');
         const templateFiles = core.getInput('template-files');
         const sortValuesOrder = core.getInput('sort-values-order');
+        const skipVersionFooter = core.getInput('skip-version-footer');
         const gitPush = core.getBooleanInput('git-push');
         const gitPushUserName = core.getInput('git-push-user-name');
         const gitPushUserEmail = core.getInput('git-push-user-email');
@@ -34642,6 +34643,9 @@ async function run() {
         if (sortValuesOrder) {
             args.push('--sort-values-order');
             args.push(sortValuesOrder);
+        }
+        if (skipVersionFooter) {
+            args.push('--skip-version-footer');
         }
         for (const templateFile of templateFilesArray) {
             args.push('--template-files');

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ export async function run(): Promise<void> {
     const outputFile = core.getInput('output-file')
     const templateFiles = core.getInput('template-files')
     const sortValuesOrder = core.getInput('sort-values-order')
+    const skipVersionFooter = core.getInput('skip-version-footer')
     const gitPush = core.getBooleanInput('git-push')
     const gitPushUserName = core.getInput('git-push-user-name')
     const gitPushUserEmail = core.getInput('git-push-user-email')
@@ -49,6 +50,10 @@ export async function run(): Promise<void> {
     if (sortValuesOrder) {
       args.push('--sort-values-order')
       args.push(sortValuesOrder)
+    }
+
+    if (skipVersionFooter) {
+      args.push('--skip-version-footer')
     }
 
     for (const templateFile of templateFilesArray) {


### PR DESCRIPTION
This adds control over the `--skip-version-footer` option from helm-docs.

It also fixes, in a separate commit, the name of the `sort-values-order` in the README. I can make a separate PR for that if you prefer.