### PR TITLE
Fix 'unexpected input' warning

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -22,6 +22,10 @@ inputs:
     description: Order in which to sort the values table
     required: false
     default: ""
+  skip-version-footer:
+    description: If true the helm-docs version footer will not be shown in the default README template
+    required: false
+    default: 'false'
   git-push:
     description: If true it will commit and push the changes (ignored if `fail-on-diff` is set)
     required: false


### PR DESCRIPTION
Using the latest version with the new `skip-version-footer` option, I got the following warning:
```
Warning: Unexpected input(s) 'skip-version-footer', valid inputs are ['chart-search-root', 'values-file', 'output-file', 'template-files', 'sort-values-order', 'git-push', 'git-push-user-name', 'git-push-user-email', 'git-commit-message', 'fail-on-diff']
```

I'm not very familiar with Github Actions development, but this will hopefully remove the warning.