### PR TITLE
Introduced an input for helm-docs version in action.yaml

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -46,6 +46,10 @@ inputs:
     description: Fail the job if there is any diff found between the generated output and existing file
     required: false
     default: 'false'
+  version:
+    description: The version of helm-docs to install and use	
+    required: false
+    default: 'v1.14.2'
 outputs:
    helm-docs-path:
       description: 'Path to the cached helm-docs binary'


### PR DESCRIPTION
Currently, in our repo we get an error when runing the action:

```
Warning: Unexpected input(s) 'version', valid inputs are ['chart-search-root', 'values-file', 'output-file', 'template-files', 'sort-values-order', 'skip-version-footer', 'git-push', 'git-push-user-name', 'git-push-user-email', 'git-commit-message', 'fail-on-diff']
```

It is caused by absence of `version` inside the action inputs YAML.